### PR TITLE
Add extra hint pointer for command arguments

### DIFF
--- a/exercises/my_first_io/problem.md
+++ b/exercises/my_first_io/problem.md
@@ -25,4 +25,5 @@ Documentation on `Buffer`s can be found by pointing your browser here:
 
 If you're looking for an easy way to count the number of newlines in a string, recall that a JavaScript `String` can be `.split()` into an array of substrings and that '\n' can be used as a delimiter. Note that the test file does not have a newline character ('\n') at the end of the last line, so using this method you'll end up with an array that has one more element than the number of newlines.
 
+If you are having trouble getting the right command line argument please check the hints for `process.argv` in "Baby Steps".
 ----------------------------------------------------------------------


### PR DESCRIPTION
A few folks have gotten stuck briefly** on process.argv[2] in the IO exercises. Since that's not really the focus of the tutorial past (Baby Steps), overtly and briefly hint that the answer is in the previous tutorial. 

There should be no need to repeat this hint later or paste the entire hint from Baby Steps here.

hth,
adric

** EG https://github.com/nodeschool/discussions/issues/217