### PR TITLE
add instructions for no-sudo installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@
 
 Once you have finished <b><code>learnyounode</code></b>, graduate to <b><code>[stream-adventure](https://github.com/substack/stream-adventure)</code></b> for a set of exercises that dig in to Node's streams.
 
+### What if I don't have sudo rights?
+
+<b><code>learnyounode</code></b> can also be installed if you don't have root access:
+
+  1. Run `npm install learnyounode` instead of `sudo npm install learnyounode -g`
+  2. Run `$(npm bin)/learnyounode` wherever the instructions say "run `learnyounode`"
+
 ### Contributors
 
 <b><code>learnyounode</code></b> is proudly brought to you by the following hackers:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Once you have finished <b><code>learnyounode</code></b>, graduate to <b><code>[s
 
   1. Run `npm install learnyounode` instead of `sudo npm install learnyounode -g`
   2. Run `$(npm bin)/learnyounode` wherever the instructions say "run `learnyounode`"
+  3. Or alternatively to step 2 above, tweak your `PATH` to include `$(npm bin)` if you know how to do that.
 
 ### Contributors
 


### PR DESCRIPTION
Some users may not have sudo and therefore cannot easily do `npm install -g`. Learnyounode seems to work well when it's installed locally, just needs to be run as `$(npm bin)/learnyounode` unless the user is advanced enough to tweak their PATH.