### PR TITLE
guards for no `this.*` properties in cleanup

### DIFF
--- a/exercises/http_client/exercise.js
+++ b/exercises/http_client/exercise.js
@@ -49,6 +49,9 @@ exercise.addSetup(function (mode, callback) {
 exercise.addCleanup(function (mode, passed, callback) {
   // mode == 'run' || 'verify'
 
+  if (!this.server)
+    return process.nextTick(callback)
+
   this.server.close(callback)
 })
 

--- a/exercises/juggling_async/exercise.js
+++ b/exercises/juggling_async/exercise.js
@@ -82,6 +82,9 @@ exercise.addSetup(function (mode, callback) {
 exercise.addCleanup(function (mode, passed, callback) {
   // mode == 'run' || 'verify'
 
+  if (!this.servers)
+    return process.nextTick(callback)
+
   // close all 3 servers
   var done = after(3, callback)
   this.servers.forEach(function (s) {


### PR DESCRIPTION
Could be caused by a bad setup, there's no guarantee that everything is where it should be @ setup so don't make assumptions